### PR TITLE
Updating Ubuntu image

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ for i in `seq 1 2`; do
         --name webVM$i \
         --nics webNic$i \
         --location $Location \
-        --image UbuntuLTS \
+        --image Ubuntu2204 \
         --availability-set portalAvailabilitySet \
         --generate-ssh-keys \
         --custom-data cloud-init.txt


### PR DESCRIPTION
Correct URN for this image should be Ubuntu2204, please see output below from Azure CLI to support this change.


az vm image list | grep "Ubuntu"
WARNING: You are viewing an offline list of images, use --all to retrieve an up-to-date list
    "urnAlias": "Ubuntu2204",


The current value "UbuntuLTS" seems to be outdated as you get the error below.

Creating webVM1
Invalid image "UbuntuLTS". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1'].
See vm create -h for more information on specifying an image.

Cheers